### PR TITLE
The port_sources path must be enclosed in a list

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,4 @@
-{port_sources, [{ "R14", "c_src/*.c"}, {"R14", "c_src/yajl/*.c"}]}.
+{port_sources, [{"R14", ["c_src/*.c"]}, {"R14", ["c_src/yajl/*.c"]}]}.
 
 {so_name, "ejson.so"}.
 


### PR DESCRIPTION
The `port_sources` path in `rebar.config` must be enclosed in a list.
